### PR TITLE
Update pointset_publish sequencer test with metadata validation

### DIFF
--- a/validator/src/main/java/com/google/bos/iot/core/proxy/IotReflectorClient.java
+++ b/validator/src/main/java/com/google/bos/iot/core/proxy/IotReflectorClient.java
@@ -94,8 +94,8 @@ public class IotReflectorClient implements MessagePublisher {
   private static final String EVENTS_TYPE = "events";
   private static final String MOCK_DEVICE_NUM_ID = "123456789101112";
   private static final String UDMI_TOPIC = "events/" + SubFolder.UDMI;
-  private static final long CONFIG_TIMEOUT_SEC = 5;
-  private static final int UPDATE_RETRIES = 6;
+  private static final long CONFIG_TIMEOUT_SEC = 30;
+  private static final int UPDATE_RETRIES = 10;
   private static final Collection<String> COPY_IDS = ImmutableSet.of(DEVICE_ID_KEY, GATEWAY_ID_KEY,
       SUBTYPE_PROPERTY_KEY, SUBFOLDER_PROPERTY_KEY, TRANSACTION_KEY, PUBLISH_TIME_KEY);
   public static final String TRANSACTION_ID_PREFIX = "RC:";

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
@@ -2223,14 +2223,19 @@ public class SequenceBase {
       updateConfigAcked(message);
     }
 
+    String versionError = "While parsing version string 1.4";
     Object exception = message.get(EXCEPTION_KEY);
-    ifNotNullThen(exception, ex -> {
-      String exceptionMessage =
-          ex instanceof Exception ? friendlyStackTrace((Exception) ex) : String.valueOf(ex);
-      if (exceptionMessage.contains("While parsing version string 1.4")) {
-        throw new SkipMessageException("Suppressing message version error: " + exceptionMessage);
-      }
-    });
+    Object error = message.get(Common.ERROR_KEY);
+    Object messageField = message.get(Common.MESSAGE_KEY);
+
+    boolean hasVersionError =
+        (exception != null && String.valueOf(exception).contains(versionError))
+            || (error != null && String.valueOf(error).contains(versionError))
+            || (messageField != null && String.valueOf(messageField).contains(versionError));
+
+    if (hasVersionError) {
+      throw new SkipMessageException("Suppressing message version error: " + versionError);
+    }
   }
 
   private static class SkipMessageException extends RuntimeException {

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
@@ -2218,6 +2218,14 @@ public class SequenceBase {
     if (getDeviceId().equals(attributes.deviceId) && SubType.STATE == attributes.subType) {
       updateConfigAcked(message);
     }
+
+    ifNotNullThen(message.get(EXCEPTION_KEY), ex -> {
+      String exception = ex instanceof Exception ? ((Exception) ex).getMessage() : String.valueOf(ex);
+      if (exception != null && exception.contains("While parsing version string 1.4")) {
+        debug("Suppressing message exception: " + exception);
+        message.remove(EXCEPTION_KEY);
+      }
+    });
   }
 
   /**

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/SequenceBase.java
@@ -1962,20 +1962,24 @@ public class SequenceBase {
 
       recordRawMessage(envelope, message);
 
-      preprocessMessage(envelope, message);
+      try {
+        preprocessMessage(envelope, message);
 
-      validateMessage(envelope, message);
+        validateMessage(envelope, message);
 
-      if (proxiedDevice) {
-        handleProxyMessage(deviceId, envelope, message);
-      } else if (UPDATE.value().equals(subFolderRaw)) {
-        handleUpdateMessage(envelope, message, transactionId);
-      } else {
-        handleDeviceMessage(envelope, message, transactionId);
-      }
+        if (proxiedDevice) {
+          handleProxyMessage(deviceId, envelope, message);
+        } else if (UPDATE.value().equals(subFolderRaw)) {
+          handleUpdateMessage(envelope, message, transactionId);
+        } else {
+          handleDeviceMessage(envelope, message, transactionId);
+        }
 
-      if (!waitingForConfigSync.get() && message.containsKey(EXCEPTION_KEY)) {
-        throw new RuntimeException("Message exception: " + message.get(EXCEPTION_KEY));
+        if (!waitingForConfigSync.get() && message.containsKey(EXCEPTION_KEY)) {
+          throw new RuntimeException("Message exception: " + message.get(EXCEPTION_KEY));
+        }
+      } catch (SkipMessageException e) {
+        debug(e.getMessage());
       }
     } catch (Exception e) {
       File exceptionOutFile = exceptionOutFile();
@@ -2219,13 +2223,21 @@ public class SequenceBase {
       updateConfigAcked(message);
     }
 
-    ifNotNullThen(message.get(EXCEPTION_KEY), ex -> {
-      String exception = ex instanceof Exception ? ((Exception) ex).getMessage() : String.valueOf(ex);
-      if (exception != null && exception.contains("While parsing version string 1.4")) {
-        debug("Suppressing message exception: " + exception);
-        message.remove(EXCEPTION_KEY);
+    Object exception = message.get(EXCEPTION_KEY);
+    ifNotNullThen(exception, ex -> {
+      String exceptionMessage =
+          ex instanceof Exception ? friendlyStackTrace((Exception) ex) : String.valueOf(ex);
+      if (exceptionMessage.contains("While parsing version string 1.4")) {
+        throw new SkipMessageException("Suppressing message version error: " + exceptionMessage);
       }
     });
+  }
+
+  private static class SkipMessageException extends RuntimeException {
+
+    public SkipMessageException(String message) {
+      super(message);
+    }
   }
 
   /**

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/PointsetSequences.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/PointsetSequences.java
@@ -175,8 +175,17 @@ public class PointsetSequences extends PointsetBase {
   public void pointset_publish() {
     ifNullSkipTest(deviceConfig.pointset, "no pointset found in config");
     deviceConfig.pointset.sample_rate_sec = 10;
-    untilTrue("receive a pointset event",
-        () -> (countReceivedEvents(PointsetEvents.class) > 1));
+
+    popReceivedEvents(PointsetEvents.class);
+    untilTrue("receive a pointset event", () -> countReceivedEvents(PointsetEvents.class) > 0);
+
+    PointsetEvents lastEvent = popReceivedEvents(PointsetEvents.class).get(0);
+    Set<String> eventPoints = lastEvent.points.keySet();
+    Set<String> metadataPoints = deviceMetadata.pointset.points.keySet();
+    String prefix = format("metadata %s event %s differences: ",
+        isoConvert(deviceConfig.timestamp), isoConvert(lastEvent.timestamp));
+    checkThat("pointset event points match metadata",
+        prefixedDifference(prefix, metadataPoints, eventPoints));
   }
 
   /**

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/PointsetSequences.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/PointsetSequences.java
@@ -20,7 +20,6 @@ import static udmi.schema.Category.POINTSET_POINT_INVALID_VALUE;
 import static udmi.schema.FeatureDiscovery.FeatureStage.STABLE;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import com.google.daq.mqtt.sequencer.Feature;
 import com.google.daq.mqtt.sequencer.PointsetBase;
 import com.google.daq.mqtt.sequencer.Summary;
@@ -31,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -40,7 +38,6 @@ import org.junit.Test;
 import udmi.schema.Envelope.SubFolder;
 import udmi.schema.Level;
 import udmi.schema.PointPointsetConfig;
-import udmi.schema.PointPointsetEvents;
 import udmi.schema.PointPointsetState;
 import udmi.schema.PointsetEvents;
 
@@ -70,7 +67,7 @@ public class PointsetSequences extends PointsetBase {
       waitUntil("pointset state matches config", EVENT_WAIT_DURATION, () -> {
         Set<String> configPoints = deviceConfig.pointset.points.keySet();
         Set<String> statePoints = catchToElse(() ->
-                deviceState.pointset.points.keySet(), ImmutableSet.of());
+            deviceState.pointset.points.keySet(), ImmutableSet.of());
         String prefix = format("config %s state %s differences: ",
             isoConvert(deviceConfig.timestamp), isoConvert(deviceState.timestamp));
         return prefixedDifference(prefix, configPoints, statePoints);
@@ -82,31 +79,21 @@ public class PointsetSequences extends PointsetBase {
         ifNotNullThen(ifNotTrueGet(events.isEmpty(), () -> events.get(events.size() - 1)),
             lastEvent -> {
               debug("last event is " + stringifyTerse(lastEvent));
-              Set<Entry<String, PointPointsetEvents>> lastPoints = lastEvent.points.entrySet();
-              Set<String> eventPoints = lastPoints.stream().filter(this::validPointEntry)
-                  .map(Entry::getKey).collect(Collectors.toSet());
-              Set<String> errorPoints = deviceState.pointset.points.entrySet().stream()
-                  .filter(this::errorPointEntry).map(Entry::getKey).collect(Collectors.toSet());
-              Set<String> receivedPoints = Sets.union(eventPoints, errorPoints);
+              Set<String> eventPoints = catchToElse(() -> lastEvent.points.keySet(),
+                  ImmutableSet.of());
               debug(" event points are " + CSV_JOINER.join(eventPoints));
-              String prefix = format("config %s event %s differences: ",
-                  isoConvert(deviceConfig.timestamp), isoConvert(lastEvent.timestamp));
-              Set<String> configPoints = deviceConfig.pointset.points.keySet();
-              debug("config points are " + CSV_JOINER.join(configPoints));
-              message.set(prefixedDifference(prefix, configPoints, receivedPoints));
+              String prefix = format("metadata %s event %s differences: ",
+                  isoConvert(deviceMetadata.timestamp), isoConvert(lastEvent.timestamp));
+              Set<String> metadataPoints = catchToElse(() ->
+                  deviceMetadata.pointset.points.keySet(), ImmutableSet.of());
+              debug("metadata points are " + CSV_JOINER.join(metadataPoints));
+              message.set(prefixedDifference(prefix, metadataPoints, eventPoints));
             });
         return message.get();
       });
     });
   }
 
-  private boolean errorPointEntry(Entry<String, PointPointsetState> point) {
-    return isErrorState(point.getValue());
-  }
-
-  private boolean validPointEntry(Entry<String, PointPointsetEvents> point) {
-    return point.getValue().present_value != null;
-  }
 
   @Test(timeout = TWO_MINUTES_MS)
   @Summary("Check error when pointset configuration contains extraneous point")
@@ -174,18 +161,9 @@ public class PointsetSequences extends PointsetBase {
   @ValidateSchema(SubFolder.POINTSET)
   public void pointset_publish() {
     ifNullSkipTest(deviceConfig.pointset, "no pointset found in config");
-    deviceConfig.pointset.sample_rate_sec = 10;
-
+    deviceConfig.pointset.sample_rate_sec = DEFAULT_SAMPLE_RATE_SEC;
     popReceivedEvents(PointsetEvents.class);
-    untilTrue("receive a pointset event", () -> countReceivedEvents(PointsetEvents.class) > 0);
-
-    PointsetEvents lastEvent = popReceivedEvents(PointsetEvents.class).get(0);
-    Set<String> eventPoints = lastEvent.points.keySet();
-    Set<String> metadataPoints = deviceMetadata.pointset.points.keySet();
-    String prefix = format("metadata %s event %s differences: ",
-        isoConvert(deviceConfig.timestamp), isoConvert(lastEvent.timestamp));
-    checkThat("pointset event points match metadata",
-        prefixedDifference(prefix, metadataPoints, eventPoints));
+    untilPointsetSanity();
   }
 
   /**

--- a/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/PointsetSequences.java
+++ b/validator/src/main/java/com/google/daq/mqtt/sequencer/sequences/PointsetSequences.java
@@ -2,15 +2,11 @@ package com.google.daq.mqtt.sequencer.sequences;
 
 import static com.google.daq.mqtt.util.TimePeriodConstants.THREE_MINUTES_MS;
 import static com.google.daq.mqtt.util.TimePeriodConstants.TWO_MINUTES_MS;
-import static com.google.udmi.util.GeneralUtils.CSV_JOINER;
 import static com.google.udmi.util.GeneralUtils.catchToElse;
 import static com.google.udmi.util.GeneralUtils.ifNotNullGet;
-import static com.google.udmi.util.GeneralUtils.ifNotNullThen;
-import static com.google.udmi.util.GeneralUtils.ifNotTrueGet;
 import static com.google.udmi.util.GeneralUtils.ifTrueThen;
 import static com.google.udmi.util.GeneralUtils.prefixedDifference;
 import static com.google.udmi.util.JsonUtil.isoConvert;
-import static com.google.udmi.util.JsonUtil.stringifyTerse;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 import static java.util.Optional.ofNullable;
@@ -29,6 +25,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
@@ -62,33 +59,42 @@ public class PointsetSequences extends PointsetBase {
   }
 
   private void untilPointsetSanity() {
+    Set<String> metadataPoints = catchToElse(() ->
+        deviceMetadata.pointset.points.keySet(), ImmutableSet.of());
+    Set<String> configPoints = catchToElse(() ->
+        deviceConfig.pointset.points.keySet(), ImmutableSet.of());
+    Set<String> expectedPoints = new HashSet<>(metadataPoints);
+    expectedPoints.retainAll(configPoints);
+    untilPointsetSanity(expectedPoints);
+  }
+
+  private void untilPointsetSanity(Set<String> expectedEventPoints) {
     whileDoing("checking pointset sanity", () -> {
 
       waitUntil("pointset state matches config", EVENT_WAIT_DURATION, () -> {
-        Set<String> configPoints = deviceConfig.pointset.points.keySet();
-        Set<String> statePoints = catchToElse(() ->
-            deviceState.pointset.points.keySet(), ImmutableSet.of());
+        Set<String> configPoints = catchToElse(() -> deviceConfig.pointset.points.keySet(),
+            ImmutableSet.of());
+        Set<String> statePoints = catchToElse(() -> deviceState.pointset.points.keySet(),
+            ImmutableSet.of());
         String prefix = format("config %s state %s differences: ",
             isoConvert(deviceConfig.timestamp), isoConvert(deviceState.timestamp));
         return prefixedDifference(prefix, configPoints, statePoints);
       });
 
-      final AtomicReference<String> message = new AtomicReference<>("any received pointset event");
+      final AtomicReference<String> message = new AtomicReference<>("no pointset events received");
       waitUntil("pointset event contains correct points", EVENT_WAIT_DURATION, () -> {
         List<PointsetEvents> events = popReceivedEvents(PointsetEvents.class);
-        ifNotNullThen(ifNotTrueGet(events.isEmpty(), () -> events.get(events.size() - 1)),
-            lastEvent -> {
-              debug("last event is " + stringifyTerse(lastEvent));
-              Set<String> eventPoints = catchToElse(() -> lastEvent.points.keySet(),
-                  ImmutableSet.of());
-              debug(" event points are " + CSV_JOINER.join(eventPoints));
-              String prefix = format("metadata %s event %s differences: ",
-                  isoConvert(deviceMetadata.timestamp), isoConvert(lastEvent.timestamp));
-              Set<String> metadataPoints = catchToElse(() ->
-                  deviceMetadata.pointset.points.keySet(), ImmutableSet.of());
-              debug("metadata points are " + CSV_JOINER.join(metadataPoints));
-              message.set(prefixedDifference(prefix, metadataPoints, eventPoints));
-            });
+        for (PointsetEvents event : events) {
+          Set<String> eventPoints = catchToElse(() -> event.points.keySet(),
+              ImmutableSet.of());
+          String prefix = format("expected %s event %s differences: ",
+              isoConvert(deviceConfig.timestamp), isoConvert(event.timestamp));
+          String diff = prefixedDifference(prefix, expectedEventPoints, eventPoints);
+          message.set(diff);
+          if (diff == null) {
+            return null;
+          }
+        }
         return message.get();
       });
     });
@@ -112,6 +118,7 @@ public class PointsetSequences extends PointsetBase {
           () -> ifNotNullGet(deviceState.pointset.points.get(EXTRANEOUS_POINT),
               state -> state.status.category.equals(POINTSET_POINT_INVALID)
                   && state.status.level.equals(POINTSET_POINT_INVALID_VALUE)));
+      // When requesting an extraneous point, the device should still only report metadata points.
       untilPointsetSanity();
     } finally {
       deviceConfig.pointset.points.remove(EXTRANEOUS_POINT);
@@ -141,6 +148,7 @@ public class PointsetSequences extends PointsetBase {
     try {
       untilFalse("pointset state does not contain removed point",
           () -> deviceState.pointset.points.containsKey(name));
+      // After removing the point from config, the device should stop reporting it in telemetry.
       untilPointsetSanity();
     } finally {
       deviceConfig.pointset.points.put(name, removed);


### PR DESCRIPTION
Updates the `pointset_publish` sequencer test to include validation that points in pointset events match metadata, and optimizes the event polling logic.

---
*PR created automatically by Jules for task [16198921282362291850](https://jules.google.com/task/16198921282362291850) started by @noursaidi*