### PR TITLE
Bump UDMI version to 1.5.3 / Functions 19

### DIFF
--- a/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
+++ b/services/src/main/java/com/google/bos/iot/core/bambi/LocalSiteModelManager.java
@@ -13,7 +13,7 @@ import static com.google.udmi.util.JsonUtil.flattenNestedMap;
 import static com.google.udmi.util.JsonUtil.isoConvert;
 import static com.google.udmi.util.JsonUtil.nestFlattenedJson;
 import static com.google.udmi.util.JsonUtil.writeFormattedFile;
-import static udmi.util.SchemaVersion.VERSION_1_5_2;
+import static udmi.util.SchemaVersion.VERSION_1_5_3;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
@@ -216,7 +216,7 @@ public class LocalSiteModelManager {
       updateTimestamp(originalData, true);
     }
     if (!originalData.containsKey(VERSION_KEY)) {
-      originalData.put(VERSION_KEY, VERSION_1_5_2.key());
+      originalData.put(VERSION_KEY, VERSION_1_5_3.key());
     }
     // Merge all data including any renamed points
     Map<String, String> mergedData = merge(originalData, receivedUpdate, true);

--- a/udmis/src/main/java/com/google/bos/udmi/service/pod/ContainerBase.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/pod/ContainerBase.java
@@ -51,8 +51,8 @@ import udmi.schema.PodConfiguration;
 public abstract class ContainerBase implements UdmiComponent {
 
   public static final String INITIAL_EXECUTION_CONTEXT = "xxxxxxxx";
-  public static final Integer FUNCTIONS_VERSION_MIN = 18;
-  public static final Integer FUNCTIONS_VERSION_MAX = 18;
+  public static final Integer FUNCTIONS_VERSION_MIN = 19;
+  public static final Integer FUNCTIONS_VERSION_MAX = 19;
   public static final String EMPTY_JSON = "{}";
   public static final String REFLECT_BASE = "UDMI-REFLECT";
   private static final ThreadLocal<String> executionContext = new ThreadLocal<>();

--- a/validator/src/main/java/com/google/daq/mqtt/util/ConfigUtil.java
+++ b/validator/src/main/java/com/google/daq/mqtt/util/ConfigUtil.java
@@ -19,7 +19,7 @@ import udmi.schema.ExecutionConfiguration;
 public abstract class ConfigUtil {
 
   public static final String EXCEPTIONS_JSON = "exceptions.json";
-  public static final String UDMI_VERSION = "1.5.2";
+  public static final String UDMI_VERSION = "1.5.3";
   public static final String UDMI_TOOLS = System.getenv(UDMI_VERSION_KEY);
   public static final File UDMI_ROOT = new File(ofNullable(System.getenv("UDMI_ROOT")).orElse("."));
 

--- a/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
+++ b/validator/src/main/java/com/google/daq/mqtt/validator/Validator.java
@@ -131,7 +131,7 @@ import udmi.schema.ValidationSummary;
  */
 public class Validator {
 
-  public static final int TOOLS_FUNCTIONS_VERSION = 18;
+  public static final int TOOLS_FUNCTIONS_VERSION = 19;
   public static final String PROJECT_PROVIDER_PREFIX = "//";
   public static final String TIMESTAMP_ZULU_SUFFIX = "Z";
   public static final String TIMESTAMP_UTC_SUFFIX_1 = "+00:00";


### PR DESCRIPTION
This change updates the minimum required UDMI version across the validator tools and the UDMIS service.

- Incremented integer feature version (functions version) from 18 to 19.
- Updated semantic UDMI version from 1.5.2 to 1.5.3.
- Ensured consistency in LocalSiteModelManager by using the latest SchemaVersion constant.

These changes enforce the latest version requirements for both local tools and cloud service components.

---
*PR created automatically by Jules for task [2816503647612826316](https://jules.google.com/task/2816503647612826316) started by @noursaidi*