### PR TITLE
Add region to site and device metadata with automatic propagation

### DIFF
--- a/gencode/java/udmi/schema/Location.java
+++ b/gencode/java/udmi/schema/Location.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
     "site",
+    "region",
     "panel",
     "section",
     "room",
@@ -32,6 +33,13 @@ public class Location {
     @JsonProperty("site")
     @JsonPropertyDescription("The site name according to the site model in which the device is installed in")
     public String site;
+    /**
+     * The region according to the site model in which the device is installed in
+     *
+     */
+    @JsonProperty("region")
+    @JsonPropertyDescription("The region according to the site model in which the device is installed in")
+    public String region;
     /**
      * The reference of the panel where the device is installed in
      * 
@@ -70,6 +78,7 @@ public class Location {
         result = ((result* 31)+((this.coordinates == null)? 0 :this.coordinates.hashCode()));
         result = ((result* 31)+((this.section == null)? 0 :this.section.hashCode()));
         result = ((result* 31)+((this.position == null)? 0 :this.position.hashCode()));
+        result = ((result* 31)+((this.region == null)? 0 :this.region.hashCode()));
         result = ((result* 31)+((this.panel == null)? 0 :this.panel.hashCode()));
         result = ((result* 31)+((this.floor == null)? 0 :this.floor.hashCode()));
         result = ((result* 31)+((this.room == null)? 0 :this.room.hashCode()));
@@ -85,7 +94,7 @@ public class Location {
             return false;
         }
         Location rhs = ((Location) other);
-        return (((((((((this.site == rhs.site)||((this.site!= null)&&this.site.equals(rhs.site)))&&((this.floor_seq == rhs.floor_seq)||((this.floor_seq!= null)&&this.floor_seq.equals(rhs.floor_seq))))&&((this.coordinates == rhs.coordinates)||((this.coordinates!= null)&&this.coordinates.equals(rhs.coordinates))))&&((this.section == rhs.section)||((this.section!= null)&&this.section.equals(rhs.section))))&&((this.position == rhs.position)||((this.position!= null)&&this.position.equals(rhs.position))))&&((this.panel == rhs.panel)||((this.panel!= null)&&this.panel.equals(rhs.panel))))&&((this.floor == rhs.floor)||((this.floor!= null)&&this.floor.equals(rhs.floor))))&&((this.room == rhs.room)||((this.room!= null)&&this.room.equals(rhs.room))));
+        return ((((((((((this.site == rhs.site)||((this.site!= null)&&this.site.equals(rhs.site)))&&((this.floor_seq == rhs.floor_seq)||((this.floor_seq!= null)&&this.floor_seq.equals(rhs.floor_seq))))&&((this.coordinates == rhs.coordinates)||((this.coordinates!= null)&&this.coordinates.equals(rhs.coordinates))))&&((this.section == rhs.section)||((this.section!= null)&&this.section.equals(rhs.section))))&&((this.position == rhs.position)||((this.position!= null)&&this.position.equals(rhs.position))))&&((this.region == rhs.region)||((this.region!= null)&&this.region.equals(rhs.region))))&&((this.panel == rhs.panel)||((this.panel!= null)&&this.panel.equals(rhs.panel))))&&((this.floor == rhs.floor)||((this.floor!= null)&&this.floor.equals(rhs.floor))))&&((this.room == rhs.room)||((this.room!= null)&&this.room.equals(rhs.room))));
     }
 
 }

--- a/gencode/java/udmi/schema/SiteMetadata.java
+++ b/gencode/java/udmi/schema/SiteMetadata.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
     "timestamp",
     "version",
     "site",
+    "region",
     "name",
     "tags",
     "strict_warnings",
@@ -55,6 +56,13 @@ public class SiteMetadata {
     @JsonProperty("site")
     @JsonPropertyDescription("Identifier for the site or building")
     public java.lang.String site;
+    /**
+     * Region for the site
+     *
+     */
+    @JsonProperty("region")
+    @JsonPropertyDescription("Region for the site")
+    public java.lang.String region;
     /**
      * Name of the site or building
      * 
@@ -111,6 +119,7 @@ public class SiteMetadata {
         result = ((result* 31)+((this.location == null)? 0 :this.location.hashCode()));
         result = ((result* 31)+((this.links == null)? 0 :this.links.hashCode()));
         result = ((result* 31)+((this.externals == null)? 0 :this.externals.hashCode()));
+        result = ((result* 31)+((this.region == null)? 0 :this.region.hashCode()));
         result = ((result* 31)+((this.version == null)? 0 :this.version.hashCode()));
         result = ((result* 31)+((this.parameters == null)? 0 :this.parameters.hashCode()));
         result = ((result* 31)+((this.strict_warnings == null)? 0 :this.strict_warnings.hashCode()));
@@ -128,7 +137,7 @@ public class SiteMetadata {
             return false;
         }
         SiteMetadata rhs = ((SiteMetadata) other);
-        return (((((((((((this.site == rhs.site)||((this.site!= null)&&this.site.equals(rhs.site)))&&((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name))))&&((this.location == rhs.location)||((this.location!= null)&&this.location.equals(rhs.location))))&&((this.links == rhs.links)||((this.links!= null)&&this.links.equals(rhs.links))))&&((this.externals == rhs.externals)||((this.externals!= null)&&this.externals.equals(rhs.externals))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.parameters == rhs.parameters)||((this.parameters!= null)&&this.parameters.equals(rhs.parameters))))&&((this.strict_warnings == rhs.strict_warnings)||((this.strict_warnings!= null)&&this.strict_warnings.equals(rhs.strict_warnings))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))))&&((this.tags == rhs.tags)||((this.tags!= null)&&this.tags.equals(rhs.tags))));
+        return ((((((((((((this.site == rhs.site)||((this.site!= null)&&this.site.equals(rhs.site)))&&((this.name == rhs.name)||((this.name!= null)&&this.name.equals(rhs.name))))&&((this.location == rhs.location)||((this.location!= null)&&this.location.equals(rhs.location))))&&((this.links == rhs.links)||((this.links!= null)&&this.links.equals(rhs.links))))&&((this.externals == rhs.externals)||((this.externals!= null)&&this.externals.equals(rhs.externals))))&&((this.region == rhs.region)||((this.region!= null)&&this.region.equals(rhs.region))))&&((this.version == rhs.version)||((this.version!= null)&&this.version.equals(rhs.version))))&&((this.parameters == rhs.parameters)||((this.parameters!= null)&&this.parameters.equals(rhs.parameters))))&&((this.strict_warnings == rhs.strict_warnings)||((this.strict_warnings!= null)&&this.strict_warnings.equals(rhs.strict_warnings))))&&((this.timestamp == rhs.timestamp)||((this.timestamp!= null)&&this.timestamp.equals(rhs.timestamp))))&&((this.tags == rhs.tags)||((this.tags!= null)&&this.tags.equals(rhs.tags))));
     }
 
 }

--- a/schema/model_system.json
+++ b/schema/model_system.json
@@ -79,6 +79,14 @@
             "style": "bold"
           }
         },
+        "region": {
+          "description": "The region according to the site model in which the device is installed in",
+          "type": "string",
+          "$presentation": {
+            "display": "show",
+            "style": "bold"
+          }
+        },
         "panel": {
           "description": "The reference of the panel where the device is installed in",
           "type": "string",

--- a/schema/site_metadata.json
+++ b/schema/site_metadata.json
@@ -34,6 +34,14 @@
         "style": "bold"
       }
     },
+    "region": {
+      "description": "Region for the site",
+      "type": "string",
+      "$presentation": {
+        "display": "show",
+        "style": "bold"
+      }
+    },
     "name": {
       "description": "Name of the site or building",
       "type": "string",

--- a/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/LocalDevice.java
@@ -19,6 +19,7 @@ import static com.google.udmi.util.GeneralUtils.deepCopy;
 import static com.google.udmi.util.GeneralUtils.ifNotNullGet;
 import static com.google.udmi.util.GeneralUtils.ifNotNullThen;
 import static com.google.udmi.util.GeneralUtils.ifNotTrueThen;
+import static com.google.udmi.util.GeneralUtils.ifNullThen;
 import static com.google.udmi.util.GeneralUtils.ifTrueThen;
 import static com.google.udmi.util.GeneralUtils.isTrue;
 import static com.google.udmi.util.GeneralUtils.writeString;
@@ -94,8 +95,11 @@ import udmi.schema.Envelope;
 import udmi.schema.Envelope.SubFolder;
 import udmi.schema.Envelope.SubType;
 import udmi.schema.GatewayModel;
+import udmi.schema.Location;
 import udmi.schema.Metadata;
 import udmi.schema.PointPointsetModel;
+import udmi.schema.SiteMetadata;
+import udmi.schema.SystemModel;
 
 
 class LocalDevice implements SiteDevice {
@@ -852,9 +856,15 @@ class LocalDevice implements SiteDevice {
     return new LocalDevice(siteModel, newId, schemas, generation, deviceKind);
   }
 
-  public void preprocessMetadata() {
+  public void preprocessMetadata(SiteMetadata siteMetadata) {
     ifTrueWarn(catchToNull(() -> metadata.cloud.config.static_file) != null,
         "Disallowed cloud.config.static_file defined");
+
+    ifNotNullThen(siteMetadata.region, region -> {
+      ifNullThen(metadata.system, () -> metadata.system = new SystemModel());
+      ifNullThen(metadata.system.location, () -> metadata.system.location = new Location());
+      ifNullThen(metadata.system.location.region, () -> metadata.system.location.region = region);
+    });
   }
 
   private void ifTrueWarn(boolean condition, String message) {

--- a/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
+++ b/validator/src/main/java/com/google/daq/mqtt/registrar/Registrar.java
@@ -1461,9 +1461,10 @@ public class Registrar {
   }
 
   private void preprocessDeviceMetadata(Map<String, LocalDevice> workingDevices) {
+    SiteMetadata siteMetadata = getSiteMetadata();
     workingDevices.values().forEach(localDevice -> {
       try {
-        localDevice.preprocessMetadata();
+        localDevice.preprocessMetadata(siteMetadata);
       } catch (ValidationError error) {
         throw new RuntimeException("While preprocessing metadata", error);
       } catch (Exception e) {

--- a/validator/src/test/java/com/google/daq/mqtt/registrar/LocalDeviceTest.java
+++ b/validator/src/test/java/com/google/daq/mqtt/registrar/LocalDeviceTest.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.util.Map;
 import org.junit.Test;
 import udmi.schema.Metadata;
+import udmi.schema.SiteMetadata;
 
 /**
  * Unit tests for LocalDevice.
@@ -55,5 +56,33 @@ public class LocalDeviceTest {
     rawMetadata.version = null;
     rawMetadata.gateway = null;
     return new LocalDevice(siteModel, DEVICE_ID, SCHEMAS, null, DeviceKind.SIMPLE);
+  }
+
+  @Test
+  public void preprocessMetadataRegion() {
+    LocalDevice localDevice = getTestInstance(EMPTY_DEFAULTS_SITE);
+    SiteMetadata siteMetadata = new SiteMetadata();
+    siteMetadata.region = "test-region";
+
+    assertNull("device region is initially null",
+        catchToNull(() -> localDevice.getMetadata().system.location.region));
+
+    localDevice.preprocessMetadata(siteMetadata);
+
+    assertEquals("device region is populated from site metadata",
+        "test-region", localDevice.getMetadata().system.location.region);
+  }
+
+  @Test
+  public void preprocessMetadataRegionExisting() {
+    LocalDevice localDevice = getTestInstance(EMPTY_DEFAULTS_SITE);
+    localDevice.getMetadata().system.location.region = "existing-region";
+    SiteMetadata siteMetadata = new SiteMetadata();
+    siteMetadata.region = "test-region";
+
+    localDevice.preprocessMetadata(siteMetadata);
+
+    assertEquals("existing device region is preserved",
+        "existing-region", localDevice.getMetadata().system.location.region);
   }
 }


### PR DESCRIPTION
This change introduces a new `region` field to the UDMI metadata schemas. It is added as a top-level property in `site_metadata.json` and as a property within the `location` object in `model_system.json` (used for device metadata).

The Registrar has been updated to automatically propagate this `region` from the site metadata to any device that does not have its own `region` explicitly set. This ensures consistency across a site while allowing for per-device overrides.

Java classes were regenerated to include the new fields, and unit tests were added to `LocalDeviceTest.java` to verify that:
1. A missing region in device metadata is correctly populated from site metadata.
2. An existing region in device metadata is preserved and not overwritten.

---
*PR created automatically by Jules for task [17728302459280877011](https://jules.google.com/task/17728302459280877011) started by @noursaidi*