### PR TITLE
Log Mosquitto dynamic security queue metrics during processing

### DIFF
--- a/udmis/src/main/java/com/google/bos/udmi/service/support/MosquittoDynamicSecurityService.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/support/MosquittoDynamicSecurityService.java
@@ -216,8 +216,10 @@ public class MosquittoDynamicSecurityService implements MqttCallback {
       return;
     }
 
-    log.info(String.format("Processed batch of %d items (%s MB), %d remaining in queue",
-        batch.size(), (double) totalBytes / 1024 / 1024, commandQueue.size()));
+    long latency = System.currentTimeMillis() - batch.get(0).timestamp;
+    log.info(String.format(
+        "Processed batch of %d items (%s MB), %d remaining in queue, %d ms latency",
+        batch.size(), (double) totalBytes / 1024 / 1024, commandQueue.size(), latency));
 
     this.inFlightBatch = batch;
     publishBatchToBroker(batch);
@@ -442,6 +444,7 @@ public class MosquittoDynamicSecurityService implements MqttCallback {
     public final String password;
     public final String clientId;
     public final boolean isFallbackSupported;
+    public final long timestamp;
 
     /**
      * Constructor.
@@ -456,6 +459,7 @@ public class MosquittoDynamicSecurityService implements MqttCallback {
       this.password = password;
       this.clientId = clientId;
       this.isFallbackSupported = isFallbackSupported;
+      this.timestamp = System.currentTimeMillis();
     }
   }
 }

--- a/udmis/src/main/java/com/google/bos/udmi/service/support/MosquittoDynamicSecurityService.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/support/MosquittoDynamicSecurityService.java
@@ -217,9 +217,9 @@ public class MosquittoDynamicSecurityService implements MqttCallback {
     }
 
     long latency = System.currentTimeMillis() - batch.get(0).timestamp;
-    log.info(String.format(
-        "Processed batch of %d items (%s MB), %d remaining in queue, latency %d ms",
-        batch.size(), (double) totalBytes / (1024 * 1024), commandQueue.size(), latency));
+    double megabytes = (double) totalBytes / 1024 / 1024;
+    log.info("Processed batch of {} items ({} MB), {} remaining in queue, latency {} ms",
+        batch.size(), megabytes, commandQueue.size(), latency);
 
     this.inFlightBatch = batch;
     publishBatchToBroker(batch);
@@ -444,6 +444,9 @@ public class MosquittoDynamicSecurityService implements MqttCallback {
     public final String password;
     public final String clientId;
     public final boolean isFallbackSupported;
+    /**
+     * Timestamp of command creation.
+     */
     public final long timestamp = System.currentTimeMillis();
 
     /**

--- a/udmis/src/main/java/com/google/bos/udmi/service/support/MosquittoDynamicSecurityService.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/support/MosquittoDynamicSecurityService.java
@@ -216,6 +216,9 @@ public class MosquittoDynamicSecurityService implements MqttCallback {
       return;
     }
 
+    log.info(String.format("Processed batch of %d items (%s MB), %d remaining in queue",
+        batch.size(), (double) totalBytes / 1024 / 1024, commandQueue.size()));
+
     this.inFlightBatch = batch;
     publishBatchToBroker(batch);
   }

--- a/udmis/src/main/java/com/google/bos/udmi/service/support/MosquittoDynamicSecurityService.java
+++ b/udmis/src/main/java/com/google/bos/udmi/service/support/MosquittoDynamicSecurityService.java
@@ -218,8 +218,8 @@ public class MosquittoDynamicSecurityService implements MqttCallback {
 
     long latency = System.currentTimeMillis() - batch.get(0).timestamp;
     log.info(String.format(
-        "Processed batch of %d items (%s MB), %d remaining in queue, %d ms latency",
-        batch.size(), (double) totalBytes / 1024 / 1024, commandQueue.size(), latency));
+        "Processed batch of %d items (%s MB), %d remaining in queue, latency %d ms",
+        batch.size(), (double) totalBytes / (1024 * 1024), commandQueue.size(), latency));
 
     this.inFlightBatch = batch;
     publishBatchToBroker(batch);
@@ -444,7 +444,7 @@ public class MosquittoDynamicSecurityService implements MqttCallback {
     public final String password;
     public final String clientId;
     public final boolean isFallbackSupported;
-    public final long timestamp;
+    public final long timestamp = System.currentTimeMillis();
 
     /**
      * Constructor.
@@ -459,7 +459,6 @@ public class MosquittoDynamicSecurityService implements MqttCallback {
       this.password = password;
       this.clientId = clientId;
       this.isFallbackSupported = isFallbackSupported;
-      this.timestamp = System.currentTimeMillis();
     }
   }
 }


### PR DESCRIPTION
This change adds a simple log statement to the MosquittoDynamicSecurityService processing loop. Whenever a batch of commands is drained from the internal queue for publication to the broker, it logs:
- The number of commands in the batch.
- The total size of the batch in MB.
- The remaining count of items in the command queue.

This fulfills the requirement to monitor queue metrics in a lightweight manner.

---
*PR created automatically by Jules for task [11733547517792229726](https://jules.google.com/task/11733547517792229726) started by @noursaidi*